### PR TITLE
Implement some more API calls for groups, grouptypes and permissions

### DIFF
--- a/ChurchToolsApi/__init__.py
+++ b/ChurchToolsApi/__init__.py
@@ -385,6 +385,30 @@ class ChurchToolsApi:
         else:
             logging.warning("Something went wrong fetching group permissions: {}".format(response.status_code))
 
+    def update_group(self, id: int, data: dict):
+        """
+        Update the given group
+        :keyword id: int: required group id
+        :keyword data: dict: required group fields data
+        :return: dict with updated group
+        :rtype: dict
+        """
+        url = self.domain + '/api/groups/{}'.format(id)
+        headers = {
+            'accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+        response = self.session.patch(url=url, headers=headers, data=json.dumps(data))
+
+        if response.status_code == 200:
+            response_content = json.loads(response.content)
+            response_data = response_content['data'].copy()
+            logging.debug("First response of Update Group successful {}".format(response_content))
+
+            return response_data
+        else:
+            logging.warning("Something went wrong updating group: {}".format(response.status_code))
+
     def file_upload(self, source_filepath, domain_type, domain_identifier, custom_file_name=None, overwrite=False):
         """
         Helper function to upload an attachment to any module of ChurchTools

--- a/ChurchToolsApi/__init__.py
+++ b/ChurchToolsApi/__init__.py
@@ -339,6 +339,30 @@ class ChurchToolsApi:
         else:
             logging.warning("Something went wrong fetching groups hierarchies: {}".format(response.status_code))
 
+    def get_grouptypes(self, **kwargs):
+        """
+        Get list of all grouptypes
+        :keyword grouptype_id: int: optional filter by grouptype id
+        :return: dict with all grouptypes
+        :rtype: dict
+        """
+        url = self.domain + '/api/group/grouptypes'
+        if 'grouptype_id' in kwargs.keys():
+            url = url + '/{}'.format(kwargs['grouptype_id'])
+        headers = {
+            'accept': 'application/json'
+        }
+        response = self.session.get(url=url, headers=headers)
+
+        if response.status_code == 200:
+            response_content = json.loads(response.content)
+            response_data = response_content['data'].copy()
+            logging.debug("First response of Grouptypes successful {}".format(response_content))
+
+            return response_data
+        else:
+            logging.warning("Something went wrong fetching grouptypes: {}".format(response.status_code))
+
     def file_upload(self, source_filepath, domain_type, domain_identifier, custom_file_name=None, overwrite=False):
         """
         Helper function to upload an attachment to any module of ChurchTools

--- a/ChurchToolsApi/__init__.py
+++ b/ChurchToolsApi/__init__.py
@@ -363,6 +363,28 @@ class ChurchToolsApi:
         else:
             logging.warning("Something went wrong fetching grouptypes: {}".format(response.status_code))
 
+    def get_group_permissions(self, group_id: int):
+        """
+        Get permissions of the current user for the given group
+        :keyword group_id: int: required group id
+        :return: dict with permissions
+        :rtype: dict
+        """
+        url = self.domain + '/api/permissions/internal/groups/{}'.format(group_id)
+        headers = {
+            'accept': 'application/json'
+        }
+        response = self.session.get(url=url, headers=headers)
+
+        if response.status_code == 200:
+            response_content = json.loads(response.content)
+            response_data = response_content['data'].copy()
+            logging.debug("First response of Group Permissions successful {}".format(response_content))
+
+            return response_data
+        else:
+            logging.warning("Something went wrong fetching group permissions: {}".format(response.status_code))
+
     def file_upload(self, source_filepath, domain_type, domain_identifier, custom_file_name=None, overwrite=False):
         """
         Helper function to upload an attachment to any module of ChurchTools

--- a/ChurchToolsApi/__init__.py
+++ b/ChurchToolsApi/__init__.py
@@ -409,6 +409,27 @@ class ChurchToolsApi:
         else:
             logging.warning("Something went wrong updating group: {}".format(response.status_code))
 
+    def get_global_permissions(self):
+        """
+        Get global permissions of the current user
+        :return: dict with permissions
+        :rtype: dict
+        """
+        url = self.domain + '/api/permissions/global'
+        headers = {
+            'accept': 'application/json'
+        }
+        response = self.session.get(url=url, headers=headers)
+
+        if response.status_code == 200:
+            response_content = json.loads(response.content)
+            response_data = response_content['data'].copy()
+            logging.debug("First response of GLobal Permissions successful {}".format(response_content))
+
+            return response_data
+        else:
+            logging.warning("Something went wrong fetching global permissions: {}".format(response.status_code))
+
     def file_upload(self, source_filepath, domain_type, domain_identifier, custom_file_name=None, overwrite=False):
         """
         Helper function to upload an attachment to any module of ChurchTools

--- a/ChurchToolsApi/__init__.py
+++ b/ChurchToolsApi/__init__.py
@@ -318,6 +318,27 @@ class ChurchToolsApi:
         else:
             logging.warning("Something went wrong fetching groups: {}".format(response.status_code))
 
+    def get_groups_hierarchies(self):
+        """
+        Get list of all group hierarchies
+        :return: dict with all group hierarchies
+        :rtype: dict
+        """
+        url = self.domain + '/api/groups/hierarchies'
+        headers = {
+            'accept': 'application/json'
+        }
+        response = self.session.get(url=url, headers=headers)
+
+        if response.status_code == 200:
+            response_content = json.loads(response.content)
+            response_data = response_content['data'].copy()
+            logging.debug("First response of Groups Hierarchies successful {}".format(response_content))
+
+            return response_data
+        else:
+            logging.warning("Something went wrong fetching groups hierarchies: {}".format(response.status_code))
+
     def file_upload(self, source_filepath, domain_type, domain_identifier, custom_file_name=None, overwrite=False):
         """
         Helper function to upload an attachment to any module of ChurchTools

--- a/ChurchToolsApi/test_ChurchToolsApi.py
+++ b/ChurchToolsApi/test_ChurchToolsApi.py
@@ -179,6 +179,22 @@ class TestsChurchToolsApi(unittest.TestCase):
             self.assertTrue('parents' in hierarchy)
             self.assertTrue('children' in hierarchy)
 
+    def test_get_grouptypes(self):
+        """
+        IMPORTANT - This test method and the parameters used depend on the target system!
+        1. Check that the list of grouptypes can be retrieved and each element contains the keys 'id' and 'name'.
+        2. Check that a single grouptype can be retrieved and id and name are matching.
+        :return:
+        """
+        grouptypes = self.api.get_grouptypes()
+        for grouptype in grouptypes:
+            self.assertTrue('id' in grouptype)
+            self.assertTrue('name' in grouptype)
+
+        grouptype = self.api.get_grouptypes(grouptype_id=2)
+        self.assertEqual(grouptype['id'], 2)
+        self.assertEqual(grouptype['name'], 'Gruppe')
+
     def test_file_upload_replace_delete(self):
         """
         IMPORTANT - This test method and the parameters used depend on the target system!

--- a/ChurchToolsApi/test_ChurchToolsApi.py
+++ b/ChurchToolsApi/test_ChurchToolsApi.py
@@ -195,6 +195,16 @@ class TestsChurchToolsApi(unittest.TestCase):
         self.assertEqual(grouptype['id'], 2)
         self.assertEqual(grouptype['name'], 'Gruppe')
 
+    def test_get_group_permissions(self):
+        """
+        IMPORTANT - This test method and the parameters used depend on the target system!
+        Checks that the permissions for a group can be retrieved and matches the test permissions.
+        :return:
+        """
+        permissions = self.api.get_group_permissions(group_id=103)
+        self.assertEqual(permissions['churchdb']['+see group'], 0)
+        self.assertFalse(permissions['churchdb']['+edit group infos'])
+
     def test_file_upload_replace_delete(self):
         """
         IMPORTANT - This test method and the parameters used depend on the target system!

--- a/ChurchToolsApi/test_ChurchToolsApi.py
+++ b/ChurchToolsApi/test_ChurchToolsApi.py
@@ -205,6 +205,15 @@ class TestsChurchToolsApi(unittest.TestCase):
         self.assertEqual(permissions['churchdb']['+see group'], 0)
         self.assertFalse(permissions['churchdb']['+edit group infos'])
 
+    def test_update_group(self):
+        """
+        IMPORTANT - This test method and the parameters used depend on the target system!
+        Checks that a field in a group can be set to some value and the returned group has this field value set.
+        :return:
+        """
+        group = self.api.update_group(id=103, data={"note": "TestNote"})
+        self.assertEqual(group['information']['note'], "TestNote")
+
     def test_file_upload_replace_delete(self):
         """
         IMPORTANT - This test method and the parameters used depend on the target system!

--- a/ChurchToolsApi/test_ChurchToolsApi.py
+++ b/ChurchToolsApi/test_ChurchToolsApi.py
@@ -167,6 +167,18 @@ class TestsChurchToolsApi(unittest.TestCase):
         self.assertEqual(group['id'], 103)
         self.assertEqual(group['name'], 'TestGruppe')
 
+    def test_get_groups_hierarchies(self):
+        """
+        Checks that the list of group hierarchies can be retrieved and each
+        element contains the keys 'groupId', 'parents' and 'children'.
+        :return:
+        """
+        hierarchies = self.api.get_groups_hierarchies()
+        for hierarchy in hierarchies:
+            self.assertTrue('groupId' in hierarchy)
+            self.assertTrue('parents' in hierarchy)
+            self.assertTrue('children' in hierarchy)
+
     def test_file_upload_replace_delete(self):
         """
         IMPORTANT - This test method and the parameters used depend on the target system!

--- a/ChurchToolsApi/test_ChurchToolsApi.py
+++ b/ChurchToolsApi/test_ChurchToolsApi.py
@@ -214,6 +214,17 @@ class TestsChurchToolsApi(unittest.TestCase):
         group = self.api.update_group(id=103, data={"note": "TestNote"})
         self.assertEqual(group['information']['note'], "TestNote")
 
+    def test_get_global_permissions(self):
+        """
+        IMPORTANT - This test method and the parameters used depend on the target system!
+        Checks that the global permissions for the current user can be retrieved
+        and one core permission and one db permission matches the expected value.
+        :return:
+        """
+        permissions = self.api.get_global_permissions()
+        self.assertFalse(permissions['churchcore']['administer settings'])
+        self.assertFalse(permissions['churchdb']['view birthdaylist'])
+
     def test_file_upload_replace_delete(self):
         """
         IMPORTANT - This test method and the parameters used depend on the target system!


### PR DESCRIPTION
This implements the following API calls:

* `get_groups_hierarchies()` to fetch group hierarchies
* `get_grouptypes()` to fetch group types
* `get_group_permissions()` to fetch permissions of the current user for a given grouo
* `update_group()` to update group data
* `get_global_permissions()` to fetch global permissions of the current user

Solves #72, #73, #74, #75, #76